### PR TITLE
Add -wrapper flag to FASTBuild invocation.

### DIFF
--- a/FASTBuild.cs
+++ b/FASTBuild.cs
@@ -843,7 +843,7 @@ namespace UnrealBuildTool
 			string distArgument = bEnableDistribution ? "-dist" : "";
 
 
-			string FBCommandLine = string.Format("-summary {0} {1} -noprogress -config {2}", distArgument, cacheArgument, BffFilePath);
+			string FBCommandLine = string.Format("-summary {0} {1} -noprogress -wrapper -config {2}", distArgument, cacheArgument, BffFilePath);
 
 			//Interesting flags for FASTBuild: -nostoponerror, -verbose
 			ProcessStartInfo FBStartInfo = new ProcessStartInfo("fbuild", FBCommandLine);


### PR DESCRIPTION
This flag causes FBuild.exe to be called using a wrapper executable. This will
allow it to exit more cleanly when a build is stopped from within the Visual
Studio IDE.
